### PR TITLE
added get_pixel and get_pixel_rgb functions

### DIFF
--- a/apa102_pi/driver/apa102.py
+++ b/apa102_pi/driver/apa102.py
@@ -237,7 +237,7 @@ class APA102:
         start_index = 4 * led_num
 
         # Filterout the three start bitst
-        output["brightness"] = self.leds[start_index] & 0b00011111
+        output["bright_percent"] = self.leds[start_index] & 0b00011111
         output["red"] = self.leds[start_index + self.rgb[0]]
         output["green"] = self.leds[start_index + self.rgb[1]]
         output["blue"] = self.leds[start_index + self.rgb[2]]
@@ -245,7 +245,7 @@ class APA102:
         # Recalculate the percentage brightness
         # This wond be the precice value that was passed to set_pixel
         # But it wil be the value used by the LED
-        output["brightness"] = output["brightness"] * 100 / self.global_brightness
+        output["bright_percent"] = output["bright_percent"] * 100 / self.global_brightness
 
         return output
 
@@ -260,7 +260,7 @@ class APA102:
         pixel = self.get_pixel(led_num)
 
         output["rgb_color"] = pixel["red"] << 8 | pixel["green"] << 8 | pixel["blue"]
-        output["brightness"] = pixel["brightness"]
+        output["bright_percent"] = pixel["bright_percent"]
 
         return output
 

--- a/apa102_pi/driver/apa102.py
+++ b/apa102_pi/driver/apa102.py
@@ -222,6 +222,48 @@ class APA102:
                        (rgb_color & 0x00FF00) >> 8, rgb_color & 0x0000FF,
                        bright_percent)
 
+    def get_pixel(self, led_num):
+        """Gets the color and brightness of one pixel in the LED stripe.
+
+        This wont be the color that is actualy show on the stripe.
+        But rather the value stored in memory.
+        """
+        if led_num < 0:
+            return  # Pixel is invisible, so ignore
+        if led_num >= self.num_led:
+            return  # again, invisible
+
+        output = {"red": 0, "green": 0, "blue": 0, "brightness": 0}
+        start_index = 4 * led_num
+
+        # Filterout the three start bitst
+        output["brightness"] = self.leds[start_index] & 0b00011111
+        output["red"] = self.leds[start_index + self.rgb[0]]
+        output["green"] = self.leds[start_index + self.rgb[1]]
+        output["blue"] = self.leds[start_index + self.rgb[2]]
+
+        # Recalculate the percentage brightness
+        # This wond be the precice value that was passed to set_pixel
+        # But it wil be the value used by the LED
+        output["brightness"] = output["brightness"] * 100 / self.global_brightness
+
+        return output
+
+    def get_pixel_rgb(self, led_num):
+        """Gets the color of one pixel in the LED stripe.
+
+        This wont be the color that is actualy show on the stripe.
+        But rather the value stored in memory.
+        Colors are combined (3 bytes concatenated)
+        """
+        output = {"rgb_color": 0, "brightness": 0}
+        pixel = self.get_pixel(led_num)
+
+        output["rgb_color"] = pixel["red"] << 8 | pixel["green"] << 8 | pixel["blue"]
+        output["brightness"] = pixel["brightness"]
+
+        return output
+
     def rotate(self, positions=1):
         """ Rotate the LEDs by the specified number of positions.
 

--- a/apa102_pi/driver/apa102.py
+++ b/apa102_pi/driver/apa102.py
@@ -19,6 +19,8 @@ class APA102:
     Public methods are:
      - set_pixel
      - set_pixel_rgb
+     - get_pixel
+     - get_pixel_rgb
      - show
      - clear_strip
      - cleanup

--- a/apa102_pi/driver/apa102.py
+++ b/apa102_pi/driver/apa102.py
@@ -225,7 +225,7 @@ class APA102:
     def get_pixel(self, led_num):
         """Gets the color and brightness of one pixel in the LED stripe.
 
-        This wont be the color that is actualy show on the stripe.
+        This wont be the color that is actually show on the stripe.
         But rather the value stored in memory.
         """
         if led_num < 0:
@@ -243,7 +243,7 @@ class APA102:
         output["blue"] = self.leds[start_index + self.rgb[2]]
 
         # Recalculate the percentage brightness
-        # This wond be the precice value that was passed to set_pixel
+        # This wond be the precise value that was passed to set_pixel
         # But it wil be the value used by the LED
         output["bright_percent"] = output["bright_percent"] * 100 / self.global_brightness
 
@@ -252,7 +252,7 @@ class APA102:
     def get_pixel_rgb(self, led_num):
         """Gets the color of one pixel in the LED stripe.
 
-        This wont be the color that is actualy show on the stripe.
+        This wont be the color that is actually show on the stripe.
         But rather the value stored in memory.
         Colors are combined (3 bytes concatenated)
         """


### PR DESCRIPTION
Gets the color and brightness of one pixel in the LED stripe.
This wont be the color that is actually show on the stripe, But rather the value stored in memory.

The bright_percent value is recalculated from the stored binary value
And wont be the precise value used when setting the pixel
But the value will be te one that is used by the LED

usage: get_pixel( led_num ) or get_pixel_rgb( led_num )