### PR TITLE
Return the correct value for rgb_color in get_pixel_rgb

### DIFF
--- a/apa102_pi/driver/apa102.py
+++ b/apa102_pi/driver/apa102.py
@@ -293,7 +293,7 @@ class APA102:
         output = {"rgb_color": 0, "brightness": 0}
         pixel = self.get_pixel(led_num)
 
-        output["rgb_color"] = pixel["red"] << 8 | pixel["green"] << 8 | pixel["blue"]
+        output["rgb_color"] = pixel["red"] << 16 | pixel["green"] << 8 | pixel["blue"]
         output["bright_percent"] = pixel["bright_percent"]
 
         return output


### PR DESCRIPTION
Fixes the issue where get_pixel_rgb() returns an incorrect value for rgb_color due to a bit-shifting error.

Script to show the issue:
```
#!/usr/bin/python3

from apa102_pi.driver import apa102

strip = apa102.APA102(30, 'rgb')
strip.clear_strip()
strip.set_pixel_rgb(1, 8421504, bright_percent=100)
stored_data = strip.get_pixel_rgb(1)
print('color returned: ' + str(stored_data['rgb_color']))
```

The expected output is:
`color returned: 8421504`

The actual output is:
`color returned: 32896`